### PR TITLE
Add correct links for host site and issue list

### DIFF
--- a/PROJECT-BRIEF.md
+++ b/PROJECT-BRIEF.md
@@ -7,7 +7,7 @@
 - Site: https://tcl-47-smart-shopping-li-6b6a7.web.app
 - Repo: https://github.com/the-collab-lab/tcl-47-smart-shopping-list
 - Clone URL: https://github.com/the-collab-lab/tcl-47-smart-shopping-list.git
-- Issue list: https://github.com/the-collab-lab/tcl-47-smart-shopping-list/projects/1
+- Issue list: https://github.com/orgs/the-collab-lab/projects/24/views/1
 - Database: https://console.firebase.google.com/u/2/project/tcl-47-smart-shopping-list/firestore/data/~2F
 
 ### Project cadence & duration

--- a/PROJECT-BRIEF.md
+++ b/PROJECT-BRIEF.md
@@ -7,7 +7,7 @@
 - Site: https://tcl-47-smart-shopping-li-6b6a7.web.app
 - Repo: https://github.com/the-collab-lab/tcl-47-smart-shopping-list
 - Clone URL: https://github.com/the-collab-lab/tcl-47-smart-shopping-list.git
-- Issue list: https://github.com/orgs/the-collab-lab/projects/24/views/1
+- Issue list: https://github.com/the-collab-lab/tcl-47-smart-shopping-list/issues
 - Database: https://console.firebase.google.com/u/2/project/tcl-47-smart-shopping-list/firestore/data/~2F
 
 ### Project cadence & duration

--- a/PROJECT-BRIEF.md
+++ b/PROJECT-BRIEF.md
@@ -8,7 +8,7 @@
 - Repo: https://github.com/the-collab-lab/tcl-47-smart-shopping-list
 - Clone URL: https://github.com/the-collab-lab/tcl-47-smart-shopping-list.git
 - Issue list: https://github.com/the-collab-lab/tcl-47-smart-shopping-list/issues
-- Database: https://console.firebase.google.com/u/2/project/tcl-47-smart-shopping-list/firestore/data/~2F
+- Database: https://console.firebase.google.com/u/2/project/tcl-47-smart-shopping-li-6b6a7/firestore/data/~2F
 
 ### Project cadence & duration
 

--- a/PROJECT-BRIEF.md
+++ b/PROJECT-BRIEF.md
@@ -4,7 +4,7 @@
 
 ### Locations for things
 
-- Site: https://tcl-47-smart-shopping-list.web.app
+- Site: https://tcl-47-smart-shopping-li-6b6a7.web.app
 - Repo: https://github.com/the-collab-lab/tcl-47-smart-shopping-list
 - Clone URL: https://github.com/the-collab-lab/tcl-47-smart-shopping-list.git
 - Issue list: https://github.com/the-collab-lab/tcl-47-smart-shopping-list/projects/1


### PR DESCRIPTION
## Description

This PR adds the correct links to hosted site and issue list in the [PROJECT-BRIEF.md](https://github.com/the-collab-lab/tcl-47-smart-shopping-list/blob/main/PROJECT-BRIEF.md) file


## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
| ✓    | :bug: Bug fix              |
|    | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |


## Testing Steps / QA Criteria
Clicking on the links for Site and Issue list in the [PROJECT-BRIEF.md](https://github.com/the-collab-lab/tcl-47-smart-shopping-list/blob/main/PROJECT-BRIEF.md) file will give us a site or page not found error

These links will take us to an existing page
[Hosted site](https://tcl-47-smart-shopping-li-6b6a7.web.app/)
[Issue list](https://github.com/orgs/the-collab-lab/projects/24/views/1)
