### PR TITLE
Ms wn new shopping list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
 		"": {
 			"name": "smart-shopping-list-next",
 			"dependencies": {
+				"@the-collab-lab/shopping-list-utils": "^2.0.0",
 				"firebase": "^9.9.0",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
@@ -3291,6 +3292,11 @@
 			"peerDependencies": {
 				"@testing-library/dom": ">=7.21.4"
 			}
+		},
+		"node_modules/@the-collab-lab/shopping-list-utils": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@the-collab-lab/shopping-list-utils/-/shopping-list-utils-2.0.0.tgz",
+			"integrity": "sha512-VHw1bfEoqroRpzle5PJLAqfsouhdFudihtRYVZcFbsPv/LVtAWcyEHXDjp1F/ixkXxY/+qyAjaT7XixsqiWOIQ=="
 		},
 		"node_modules/@tootallnate/once": {
 			"version": "2.0.0",
@@ -12359,6 +12365,11 @@
 			"integrity": "sha512-P02xtBBa8yMaLhK8CzJCIns8rqwnF6FxhR9zs810flHOBXUYCFjLd8Io1rQrAkQRWEmW2PGdZIEdMxf/KLsqFA==",
 			"dev": true,
 			"requires": {}
+		},
+		"@the-collab-lab/shopping-list-utils": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@the-collab-lab/shopping-list-utils/-/shopping-list-utils-2.0.0.tgz",
+			"integrity": "sha512-VHw1bfEoqroRpzle5PJLAqfsouhdFudihtRYVZcFbsPv/LVtAWcyEHXDjp1F/ixkXxY/+qyAjaT7XixsqiWOIQ=="
 		},
 		"@tootallnate/once": {
 			"version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 		"npm": "^8.11.0"
 	},
 	"dependencies": {
+		"@the-collab-lab/shopping-list-utils": "^2.0.0",
 		"firebase": "^9.9.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,7 +23,7 @@ export function App() {
 	const [listToken, setListToken] = useStateWithStorage(
 		null,
 		'tcl-shopping-list-token',
-	); // Question: listToken, setListToken is not directly linked to 'useState'. How are these variables being destructured?
+	);
 
 	const createNewList = () => {
 		const newToken = generateToken();

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,8 @@ import { AddItem, Home, Layout, List } from './views';
 import { getItemData, streamListItems } from './api';
 import { useStateWithStorage } from './utils';
 
+import { generateToken } from '@the-collab-lab/shopping-list-utils';
+
 export function App() {
 	const [data, setData] = useState([]);
 	/**
@@ -19,13 +21,17 @@ export function App() {
 	 * to create and join a new list.
 	 */
 	const [listToken, setListToken] = useStateWithStorage(
-		'my test list',
+		null,
 		'tcl-shopping-list-token',
-	);
+	); // Question: listToken, setListToken is not directly linked to 'useState'. How are these variables being destructured?
+
+	const createNewList = () => {
+		const newToken = generateToken();
+		setListToken(newToken);
+	};
 
 	useEffect(() => {
 		if (!listToken) return;
-
 		/**
 		 * streamListItems` takes a `listToken` so it can commuinicate
 		 * with our database; then calls a callback function with
@@ -33,6 +39,7 @@ export function App() {
 		 *
 		 * Refer to `api/firebase.js`.
 		 */
+
 		return streamListItems(listToken, (snapshot) => {
 			/**
 			 * Read the documents in the snapshot and do some work
@@ -51,7 +58,12 @@ export function App() {
 		<Router>
 			<Routes>
 				<Route path="/" element={<Layout />}>
-					<Route index element={<Home />} />
+					<Route
+						index
+						element={
+							<Home listToken={listToken} createNewList={createNewList} />
+						}
+					/>
 					<Route path="/list" element={<List data={data} />} />
 					<Route path="/add-item" element={<AddItem />} />
 				</Route>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 
 import { AddItem, Home, Layout, List } from './views';
@@ -25,10 +25,10 @@ export function App() {
 		'tcl-shopping-list-token',
 	);
 
-	const createNewList = () => {
+	const createNewList = useCallback(() => {
 		const newToken = generateToken();
 		setListToken(newToken);
-	};
+	}, [setListToken]);
 
 	useEffect(() => {
 		if (!listToken) return;

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -1,14 +1,15 @@
 import './Home.css';
 import { Navigate } from 'react-router-dom';
+import { useCallback } from 'react';
 
 export function Home({ createNewList, listToken }) {
-	const handleClick = () => {
+	const handleClick = useCallback(() => {
 		createNewList();
-	};
+	}, [createNewList]);
 
 	return (
 		<div className="Home">
-			{listToken != null && <Navigate to={'/List'} replace={true} />}
+			{listToken && <Navigate to={'/List'} replace={true} />}
 			<p>Welcome to your smart shopping list!</p>
 			<button onClick={handleClick}>Create New List</button>
 		</div>

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -1,11 +1,20 @@
 import './Home.css';
+import { Navigate } from 'react-router-dom'; // Not sure if we want to use Navigate or useNavigate.
 
-export function Home() {
+export function Home({ createNewList, listToken }) {
+	// const navigateTo = useNavigate(); // If we use 'useNavigate'
+	const handleClick = () => {
+		createNewList();
+	};
+
 	return (
 		<div className="Home">
+			{/* If the list token does not equal null, navigate to /list else, render the rest */}
+			{listToken != null && <Navigate to={'/List'} replace={true} />}
 			<p>
 				Hello from the home (<code>/</code>) page!
 			</p>
+			<button onClick={handleClick}>Create New List</button>
 		</div>
 	);
 }

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -1,19 +1,15 @@
 import './Home.css';
-import { Navigate } from 'react-router-dom'; // Not sure if we want to use Navigate or useNavigate.
+import { Navigate } from 'react-router-dom';
 
 export function Home({ createNewList, listToken }) {
-	// const navigateTo = useNavigate(); // If we use 'useNavigate'
 	const handleClick = () => {
 		createNewList();
 	};
 
 	return (
 		<div className="Home">
-			{/* If the list token does not equal null, navigate to /list else, render the rest */}
 			{listToken != null && <Navigate to={'/List'} replace={true} />}
-			<p>
-				Hello from the home (<code>/</code>) page!
-			</p>
+			<p>Welcome to your smart shopping list!</p>
 			<button onClick={handleClick}>Create New List</button>
 		</div>
 	);

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,6 +1,7 @@
 import { ListItem } from '../components';
 
 export function List({ data }) {
+	// TODO - Use navigation similar to in Home.jsx to navigate to home page if no token or token is null
 	return (
 		<>
 			<ul>


### PR DESCRIPTION
## Description

This updated code removes the test list and provides the users with an option to create a new list. The changes utilize the @the-collab-lab/shopping-list-utils to generate a new token and automatically redirects the user to the /list page when a token is present. 

## Related Issue

closes #3 

## Acceptance Criteria
|     | Type                       |
| --- | -------------------------- |
|✓| @the-collab-lab/shopping-list-utils is added as a dependency to the project.  |
|✓| The string my test list in App.jsx is replaced with null, so users are not automatically subscribed to any list. |
If a user doesn’t already have a token:  |
 |✓| A button in the Home component allows them to create a new list |
 |✓| Clicking the button generates a new token and saves it to localStorage using the setListToken function in App.jsx. |
 |✓| Once the token has been created and saved, the user is redirected to the List view. |
 |✓| If a user does already have a token: They are automatically redirected to the List view. |
 

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓ | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
| ✓ | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

![Before](https://user-images.githubusercontent.com/100049077/194903098-dae80dbb-6a1d-4fce-8ebf-49c6c3c78291.png)

### After
<img width="733" alt="Screen Shot 2022-10-10 at 8 31 11 AM" src="https://user-images.githubusercontent.com/100049077/194902649-e025e1b6-fc76-4ee9-a8f2-3a83782ea6c0.png">

## Testing Steps / QA Criteria

1.) Install dependency (npm I)
2.) Use developer tools application in browser to delete token from local storage
3.) Navigate to home and click "Create New List" button
4.) Create New List should generate and save new token in local storage
5.) User should automatically be redirected to /list