### PR TITLE
#10-MS-WN-Next-Purchase-Date

### DIFF
--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -121,21 +121,19 @@ export async function updateItem(listId, item) {
 		totalPurchases,
 	} = item;
 
-	let currentTime = new Date();
+	let currentDate = new Date();
 
 	if (isChecked) {
 		// TODO: Handle uncheck of purchased. This involves three variables
 		// on the backend: isChecked, dateLastPurchased, and dateNextPurchased.
 		// Potential solution: change dateLast/dateNext to arrays so we have history
 	} else {
-		const updatedPurchaseCount = totalPurchases + 1;
-
 		// If the item has been purchased before, return previous estimate
 		// If this is a first time purchase return difference between the
 		// date of purchase and the date the item was created
 		const previousEstimate = dateLastPurchased
 			? getDaysBetweenDates(dateLastPurchased, dateNextPurchased)
-			: getDaysBetweenDates(dateCreated);
+			: getDaysBetweenDates(dateCreated, dateNextPurchased);
 
 		// If the item has been purchased before, return days since
 		// the last purchase. If this is a first time purchase, return
@@ -144,19 +142,29 @@ export async function updateItem(listId, item) {
 			? getDaysBetweenDates(dateLastPurchased)
 			: getDaysBetweenDates(dateCreated);
 
+		const updatedPurchaseCount = totalPurchases + 1;
+
+		console.log('previousEstimate', previousEstimate);
+		console.log('daysSinceLastTransaction', daysSinceLastTransaction);
+		console.log('updatedPurchaseCount', updatedPurchaseCount);
+
 		const updatedEstimate = calculateEstimate(
 			previousEstimate,
 			daysSinceLastTransaction,
-			totalPurchases,
+			updatedPurchaseCount,
 		);
+
+		console.log('updatedEstimate', updatedEstimate);
 
 		// Determine next date of purchase by adding the estimated days
 		// until next purchase to current date.
 		const updatedNextPurchaseDate = getFutureDate(updatedEstimate);
 
+		console.log('updatedNextPurchaseDate', updatedNextPurchaseDate);
+
 		const updatedItemData = {
 			isChecked: true,
-			dateLastPurchased: currentTime,
+			dateLastPurchased: currentDate,
 			totalPurchases: updatedPurchaseCount,
 			dateNextPurchased: updatedNextPurchaseDate,
 		};

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -121,7 +121,7 @@ export async function updateItem(listId, item) {
 		totalPurchases,
 	} = item;
 
-	let currentDate = new Date();
+	const currentDate = new Date();
 
 	if (isChecked) {
 		// TODO: Handle uncheck of purchased. This involves three variables
@@ -144,23 +144,15 @@ export async function updateItem(listId, item) {
 
 		const updatedPurchaseCount = totalPurchases + 1;
 
-		console.log('previousEstimate', previousEstimate);
-		console.log('daysSinceLastTransaction', daysSinceLastTransaction);
-		console.log('updatedPurchaseCount', updatedPurchaseCount);
-
 		const updatedEstimate = calculateEstimate(
 			previousEstimate,
 			daysSinceLastTransaction,
 			updatedPurchaseCount,
 		);
 
-		console.log('updatedEstimate', updatedEstimate);
-
 		// Determine next date of purchase by adding the estimated days
 		// until next purchase to current date.
 		const updatedNextPurchaseDate = getFutureDate(updatedEstimate);
-
-		console.log('updatedNextPurchaseDate', updatedNextPurchaseDate);
 
 		const updatedItemData = {
 			isChecked: true,

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -7,8 +7,11 @@ import {
 	doc,
 	updateDoc,
 } from 'firebase/firestore';
+
 import { db } from './config';
-import { getFutureDate } from '../utils';
+
+import { getDaysBetweenDates, getFutureDate } from '../utils';
+import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 
 /**
  * Accepts user provided token and checks database to verify this token corresponds to an existing list
@@ -88,17 +91,79 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 		totalPurchases: 0,
 	});
 }
+/**
+ * Uncheck list item when item
+ * @param {string} listId The id of the list we're adding to.
+ * @param {string} itemId The id of the list item
+ */
+export async function unCheckItem(listId, itemId) {
+	const updatedItemData = {
+		isChecked: false,
+	};
+
+	const docRef = doc(db, listId, itemId);
+	await updateDoc(docRef, updatedItemData);
+}
 
 /**
  * Update list item in Firestore.
  * @param {string} listId The id of the list we're adding to.
- * @param {string} docId The id of the list item document.
- * @param {Object} itemData Data to update in the list item.
+ * @param {Object} item list item data
  * @see https://firebase.google.com/docs/firestore/manage-data/add-data
  */
-export async function updateItem(listId, docId, itemData) {
-	const docRef = doc(db, listId, docId);
-	await updateDoc(docRef, itemData);
+export async function updateItem(listId, item) {
+	const {
+		id,
+		isChecked,
+		dateCreated,
+		dateLastPurchased,
+		dateNextPurchased,
+		totalPurchases,
+	} = item;
+
+	let currentTime = new Date();
+
+	if (isChecked) {
+		// TODO: Handle uncheck of purchased. This involves three variables
+		// on the backend: isChecked, dateLastPurchased, and dateNextPurchased.
+		// Potential solution: change dateLast/dateNext to arrays so we have history
+	} else {
+		const updatedPurchaseCount = totalPurchases + 1;
+
+		// If the item has been purchased before, return previous estimate
+		// If this is a first time purchase return difference between the
+		// date of purchase and the date the item was created
+		const previousEstimate = dateLastPurchased
+			? getDaysBetweenDates(dateLastPurchased, dateNextPurchased)
+			: getDaysBetweenDates(dateCreated);
+
+		// If the item has been purchased before, return days since
+		// the last purchase. If this is a first time purchase, return
+		// days since the item was created
+		const daysSinceLastTransaction = dateLastPurchased
+			? getDaysBetweenDates(dateLastPurchased)
+			: getDaysBetweenDates(dateCreated);
+
+		const updatedEstimate = calculateEstimate(
+			previousEstimate,
+			daysSinceLastTransaction,
+			totalPurchases,
+		);
+
+		// Determine next date of purchase by adding the estimated days
+		// until next purchase to current date.
+		const updatedNextPurchaseDate = getFutureDate(updatedEstimate);
+
+		const updatedItemData = {
+			isChecked: true,
+			dateLastPurchased: currentTime,
+			totalPurchases: updatedPurchaseCount,
+			dateNextPurchased: updatedNextPurchaseDate,
+		};
+
+		const docRef = doc(db, listId, id);
+		await updateDoc(docRef, updatedItemData);
+	}
 }
 
 export async function deleteItem() {

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,7 +1,7 @@
 import './ListItem.css';
 import { updateItem } from '../api/firebase';
 import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
-import { getDaysBetweenDates } from '../utils';
+import { getDaysBetweenDates, getFutureDate } from '../utils';
 
 export function ListItem({ name, item, listToken }) {
 	const {
@@ -39,19 +39,22 @@ export function ListItem({ name, item, listToken }) {
 				dateLastPurchased,
 				dateNextPurchased,
 			);
-			console.log(previousEstimate);
+
 			const daysSinceLastTransaction = getDaysBetweenDates(dateLastPurchased);
-			console.log(daysSinceLastTransaction);
+
 			const updatedEstimate = calculateEstimate(
 				previousEstimate,
 				daysSinceLastTransaction,
 				totalPurchases,
 			);
+
+			const updatedNextPurchaseDate = getFutureDate(updatedEstimate);
+
 			const itemData = {
 				isChecked: true,
 				dateLastPurchased: currentTime,
 				totalPurchases: updatedPurchaseCount,
-				// dateNextPurchased: undefined
+				dateNextPurchased: updatedNextPurchaseDate,
 			};
 			updateItem(listToken, id, itemData);
 		}

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,8 +1,16 @@
 import './ListItem.css';
 import { updateItem } from '../api/firebase';
+import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
+import { getDaysBetweenDates } from '../utils';
 
 export function ListItem({ name, item, listToken }) {
-	const { isChecked, id, totalPurchases, dateLastPurchased } = item;
+	const {
+		isChecked,
+		id,
+		totalPurchases,
+		dateLastPurchased,
+		dateNextPurchased,
+	} = item;
 
 	if (isChecked) {
 		//check if it's been 24 hours since item was last marked as purchased
@@ -27,10 +35,23 @@ export function ListItem({ name, item, listToken }) {
 			// Potential solution: change dateLast/dateNext to arrays so we have history
 		} else {
 			const updatedPurchaseCount = totalPurchases + 1;
+			const previousEstimate = getDaysBetweenDates(
+				dateLastPurchased,
+				dateNextPurchased,
+			);
+			console.log(previousEstimate);
+			const daysSinceLastTransaction = getDaysBetweenDates(dateLastPurchased);
+			console.log(daysSinceLastTransaction);
+			const updatedEstimate = calculateEstimate(
+				previousEstimate,
+				daysSinceLastTransaction,
+				totalPurchases,
+			);
 			const itemData = {
 				isChecked: true,
 				dateLastPurchased: currentTime,
 				totalPurchases: updatedPurchaseCount,
+				// dateNextPurchased: undefined
 			};
 			updateItem(listToken, id, itemData);
 		}

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,16 +1,8 @@
 import './ListItem.css';
-import { updateItem } from '../api/firebase';
-import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
-import { getDaysBetweenDates, getFutureDate } from '../utils';
+import { updateItem, unCheckItem } from '../api/firebase';
 
 export function ListItem({ name, item, listToken }) {
-	const {
-		isChecked,
-		id,
-		totalPurchases,
-		dateLastPurchased,
-		dateNextPurchased,
-	} = item;
+	const { isChecked, id, dateLastPurchased } = item;
 
 	if (isChecked) {
 		//check if it's been 24 hours since item was last marked as purchased
@@ -20,44 +12,12 @@ export function ListItem({ name, item, listToken }) {
 			(currentTimeInSeconds - dateLastPurchased.seconds) / 60;
 		const minutesBeforeReset = 1440; // 24 hours x 60 minutes per hour
 		if (minutesSinceLastPurchased >= minutesBeforeReset) {
-			const itemData = {
-				isChecked: false,
-			};
-			updateItem(listToken, id, itemData);
+			unCheckItem(listToken, id);
 		}
 	}
 
 	const handlePurchase = () => {
-		let currentTime = new Date();
-		if (isChecked) {
-			// TODO: Handle uncheck of purchased. This involves three variables
-			// on the backend: isChecked, dateLastPurchased, and dateNextPurchased.
-			// Potential solution: change dateLast/dateNext to arrays so we have history
-		} else {
-			const updatedPurchaseCount = totalPurchases + 1;
-			const previousEstimate = getDaysBetweenDates(
-				dateLastPurchased,
-				dateNextPurchased,
-			);
-
-			const daysSinceLastTransaction = getDaysBetweenDates(dateLastPurchased);
-
-			const updatedEstimate = calculateEstimate(
-				previousEstimate,
-				daysSinceLastTransaction,
-				totalPurchases,
-			);
-
-			const updatedNextPurchaseDate = getFutureDate(updatedEstimate);
-
-			const itemData = {
-				isChecked: true,
-				dateLastPurchased: currentTime,
-				totalPurchases: updatedPurchaseCount,
-				dateNextPurchased: updatedNextPurchaseDate,
-			};
-			updateItem(listToken, id, itemData);
-		}
+		updateItem(listToken, item);
 	};
 
 	return (

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -10,22 +10,24 @@ const ONE_DAY_IN_MILLISECONDS = 86400000;
 export function getFutureDate(offset) {
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
+
 /**
- * Get a new JavaScript Date that is `offset` days in the future.
+ * Get the difference between two dates in days
  * @example
  * // Returns a Date 3 days in the future
  * getFutureDate(3)
- * @param {number} offset
+ * @param {Object} olderDate The date which occurs first chronologically
+ * @param {Object} newerDate The date which occurs second chronologically. Defaults to current date
+ * @returns {number} The difference between the dates in days
  */
 export function getDaysBetweenDates(olderDate, newerDate) {
-	if (!newerDate) {
-		newerDate = new Date();
-		return Math.abs(newerDate - olderDate.toDate()) / 60 / 60 / 24 / 1000;
-	} else {
+	if (newerDate) {
 		return (
-			Math.abs(newerDate.toDate() - olderDate.toDate()) / 60 / 60 / 24 / 1000
+			Math.abs(newerDate.toDate() - olderDate.toDate()) /
+			ONE_DAY_IN_MILLISECONDS
 		);
+	} else {
+		const currentDate = new Date();
+		return Math.abs(currentDate - olderDate.toDate()) / ONE_DAY_IN_MILLISECONDS;
 	}
-	// console.log(Math.abs(diff/60/60/24/1000));
-	// return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -10,3 +10,22 @@ const ONE_DAY_IN_MILLISECONDS = 86400000;
 export function getFutureDate(offset) {
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
+/**
+ * Get a new JavaScript Date that is `offset` days in the future.
+ * @example
+ * // Returns a Date 3 days in the future
+ * getFutureDate(3)
+ * @param {number} offset
+ */
+export function getDaysBetweenDates(olderDate, newerDate) {
+	if (!newerDate) {
+		newerDate = new Date();
+		return Math.abs(newerDate - olderDate.toDate()) / 60 / 60 / 24 / 1000;
+	} else {
+		return (
+			Math.abs(newerDate.toDate() - olderDate.toDate()) / 60 / 60 / 24 / 1000
+		);
+	}
+	// console.log(Math.abs(diff/60/60/24/1000));
+	// return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
+}


### PR DESCRIPTION
## Description

This issue tackles the estimation of an item's next date of purchase, which is determined at the time of purchase. 

## Related Issue

closes #10

## Acceptance Criteria

- [x] A `getDaysBetweenDates` function is exported from `utils/dates.js`  and imported into `api/firebase.js`
  - [x] This function takes two JavaScript Dates and return the number of days that have passed between them
- [x] When the user purchases an item, the item’s `dateNextPurchased` property is calculated using the `calculateEstimate` function and saved to the Firestore database
  - [x] `dateNextPurchased` is saved as **a date**, not a number

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
| ✓   | :sparkles: New feature     |
| ✓   | :hammer: Refactoring       |


## Updates
- Added `getDaysBetweenDates` function
- Utilized `calculateEstimate` function to update `dateNextPurchased` as part of the overall `updateItem()` function.
- Added an `unCheckItem()` function to firebase. This function is for use with the function which unchecks an item if it was purchased over 1 day ago. This change allows for passing the entire item object into the `updateItem()` function to handle the business logic in `firebase.js` rather than in `listItem.jsx`. This also paves the way for us to add the _undo purchase_ functionality down the road.

### Before

N/A Not a UI feature

### After

N/A Not a UI feature

## Testing Steps / QA Criteria

1. git pull
2. git checkout MS-WN-Next-Purchase-Date
3. Open existing list (we used 'my test list' for testing)
4. [Open firebase console](https://console.firebase.google.com/project/tcl-47-smart-shopping-li-6b6a7/firestore/data/~2Fexcel%20allied%20tulane~2FjsCMh2mhXzrv67mNIeLC)
5. Ensure that when you check an item, that the `totalPurchases`, `dateLastPurchased`, and  `dateNextPurchased` fields are all updated. 
6. Try testing an item that has been purchased before and an item that is being purchased for the first time to ensure null values are being handled.

